### PR TITLE
Rewrite for Jekyll 3.8.0

### DIFF
--- a/lib/jekyll-postfiles.rb
+++ b/lib/jekyll-postfiles.rb
@@ -1,5 +1,6 @@
 require "jekyll-postfiles/version"
 require "jekyll"
+require "pathname"
 
 module Jekyll
 
@@ -34,30 +35,31 @@ module Jekyll
     # post - A Post which may have associated content.
     def copy_post_files(post)
 
-      post_path = post.path
+      post_path = Pathname.new post.path
       site = post.site
-      site_src_dir = site.source
+      site_src_dir = Pathname.new site.source
 
       # Jekyll.logger.warn(
       #   "[PostFiles]",
       #   "Current post: #{post_path[site_src_dir.length..-1]}"
       # )
 
-      post_dir = File.dirname(post_path)
-      dest_dir = File.dirname(post.destination(""))
+      post_dir = post_path.dirname
+      dest_dir = Pathname.new(post.destination("")).dirname
 
       # Count other Markdown files in the same directory
       other_md_count = 0
-      other_md = Dir.glob(File.join(post_dir, '*.{md,markdown}'), File::FNM_CASEFOLD) do |mdfilepath|
-        if mdfilepath != post_path
+      other_md = Dir.glob(post_dir + '*.{md,markdown}', File::FNM_CASEFOLD) do |mdfilepath|
+        if mdfilepath != post_path.to_path
           other_md_count += 1
         end
       end
 
-      contents = Dir.glob(File.join(post_dir, '*')) do |filepath|
+      contents = Dir.glob(post_dir + '**/*') do |filepath|
         if filepath != post_path \
             && !File.directory?(filepath) \
             && !File.fnmatch?('*.{md,markdown}', filepath, File::FNM_EXTGLOB | File::FNM_CASEFOLD)
+          filepath = Pathname.new(filepath)
           # Jekyll.logger.warn(
           #   "[PostFiles]",
           #   "-> attachment: #{filepath[site_src_dir.length..-1]}"
@@ -68,9 +70,13 @@ module Jekyll
               "Sorry, there can be only one Markdown file in each directory containing other assets to be copied by jekyll-postfiles"
             )
           end
-          filedir, filename = File.split(filepath[site_src_dir.length..-1])
+          relpath = filepath.relative_path_from(site_src_dir)
+          filedir, filename = relpath.dirname, relpath.basename
+
+          absfiledir = site_src_dir + filedir
+          new_dir = absfiledir.relative_path_from(post_dir)
           site.static_files <<
-            PostFile.new(site, site_src_dir, filedir, filename, dest_dir)
+            PostFile.new(site, site_src_dir, filedir, filename, (dest_dir + new_dir).to_path)
         end
       end
     end

--- a/lib/jekyll-postfiles.rb
+++ b/lib/jekyll-postfiles.rb
@@ -104,6 +104,14 @@ module Jekyll
     #     cloudflare-architecture.png
     #     performance-report-sample.pdf
     # Generate content by copying files associated with each post.
+    #
+    # the working set (site.posts.docs) is proposed by:
+    # jekyll/lib/jekyll/readers/post_reader.rb#read_posts
+    #
+    # but this is subjected to a Document::DATE_FILENAME_MATCHER
+    # which filters out deeply-nested items (only folders named like a date can survive)
+    #
+    # moreover, renderers probably expect site.posts.docs to include only markdown
     def generate(site)
       # site.posts.docs.each do |post|
       #   copy_post_files(post)
@@ -125,7 +133,7 @@ module Jekyll
         ['.md', '.markdown'].include?(Pathname.new(doc.path).extname)
       }
 
-      # reject assets
+      # reject assets; they are not renderable documents
       site.posts.docs = markdowns
 
       Jekyll.logger.warn("[PostFiles]", "assets: #{assets.map(&:path)}")
@@ -144,6 +152,13 @@ module Jekyll
           "Sorry, there can be only one Markdown file in each directory containing other assets to be copied by jekyll-postfiles. Violations: #{dirs_with_multi_md.map{ |key,value| [key.to_s, value.map(&:to_s)] }.to_h}"
         )
       end
+
+      markdowns
+        .map{ |doc| Pathname.new(doc.path) }
+        .select{ |path|
+          path.relative_path_from(posts_src_dir).each_filename.count == 2
+        }
+
       # Pathname.new('/Users/birch/Documents/tmp').relative_path_from(Pathname.new('/Users/birch')).each_filename.count
     end
   end

--- a/lib/jekyll-postfiles.rb
+++ b/lib/jekyll-postfiles.rb
@@ -69,8 +69,8 @@ module Jekyll
       posts_src_dir = site_src_dir + '_posts'
       drafts_src_dir = site_src_dir + '_drafts'
 
-      Jekyll.logger.warn("[PostFiles]", "_posts: #{posts_src_dir}")
-      Jekyll.logger.warn("[PostFiles]", "docs: #{site.posts.docs.map(&:path)}")
+      # Jekyll.logger.warn("[PostFiles]", "_posts: #{posts_src_dir}")
+      # Jekyll.logger.warn("[PostFiles]", "docs: #{site.posts.docs.map(&:path)}")
 
       docs_with_dirs = site.posts.docs
         .reject{ |doc|
@@ -81,7 +81,7 @@ module Jekyll
           }
         }
 
-      Jekyll.logger.warn("[PostFiles]", "asset_roots: #{docs_with_dirs.map{|doc| Pathname.new(doc.path).dirname}}")
+      # Jekyll.logger.warn("[PostFiles]", "asset_roots: #{docs_with_dirs.map{|doc| Pathname.new(doc.path).dirname}}")
 
       assets = docs_with_dirs.map{ |doc|
         dest_dir = Pathname.new(doc.destination("")).dirname

--- a/lib/jekyll-postfiles.rb
+++ b/lib/jekyll-postfiles.rb
@@ -39,10 +39,10 @@ module Jekyll
       site = post.site
       site_src_dir = Pathname.new site.source
 
-      # Jekyll.logger.warn(
-      #   "[PostFiles]",
-      #   "Current post: #{post_path[site_src_dir.length..-1]}"
-      # )
+      Jekyll.logger.warn(
+        "[PostFiles]",
+        "Current post: #{post_path[site_src_dir.length..-1]}"
+      )
 
       post_dir = post_path.dirname
       dest_dir = Pathname.new(post.destination("")).dirname
@@ -50,6 +50,12 @@ module Jekyll
       # Count other Markdown files in the same directory
       other_md_count = 0
       other_md = Dir.glob(post_dir + '*.{md,markdown}', File::FNM_CASEFOLD) do |mdfilepath|
+        Jekyll.logger.warn(
+          "[PostFiles]",
+          "mdfilepath: #{mdfilepath}",
+          "post_path.to_path: #{post_path.to_path}",
+          "post.path: #{post.path}",
+        )
         if mdfilepath != post_path.to_path
           other_md_count += 1
         end
@@ -60,10 +66,10 @@ module Jekyll
             && !File.directory?(filepath) \
             && !File.fnmatch?('*.{md,markdown}', filepath, File::FNM_EXTGLOB | File::FNM_CASEFOLD)
           filepath = Pathname.new(filepath)
-          # Jekyll.logger.warn(
-          #   "[PostFiles]",
-          #   "-> attachment: #{filepath[site_src_dir.length..-1]}"
-          # )
+          Jekyll.logger.warn(
+            "[PostFiles]",
+            "-> attachment: #{filepath[site_src_dir.length..-1]}"
+          )
           if other_md_count > 0
             Jekyll.logger.abort_with(
               "[PostFiles]",

--- a/lib/jekyll-postfiles.rb
+++ b/lib/jekyll-postfiles.rb
@@ -4,19 +4,11 @@ require "pathname"
 
 module Jekyll
 
-  # we hook just after the initial site.posts.docs is proposed by:
-  # jekyll/lib/jekyll/readers/post_reader.rb#read_posts
-  #
-  # Hooks.register :site, :post_read do |site|
-  #   FIXED_DATE_FILENAME_MATCHER = %r!^(?:.+/)*(\d{2,4}-\d{1,2}-\d{1,2})-([^/]*)(\.[^.]+)$!
-  #   site.posts.docs.concat(site.reader.post_reader.read_publishable)
-  # end
-
   # there's a bug in the regex Document::DATE_FILENAME_MATCHER:
   #   %r!^(?:.+/)*(\d{2,4}-\d{1,2}-\d{1,2})-(.*)(\.[^.]+)$!
   # used by:
   #   jekyll/lib/jekyll/readers/post_reader.rb#read_posts
-  # ultimately this populates:
+  # which ultimately populates:
   #   site.posts.docs
   #
   # the original code's intention was to match:
@@ -24,8 +16,8 @@ module Jekyll
   # but it accidentally matches also:
   #   all files immediately within a directory whose name contains a date
   #
-  # our plugin changes the regex
-  #   - avoid false positive when directory name matches date regex
+  # our plugin changes the regex, to:
+  #   avoid false positive when directory name matches date regex
   Hooks.register :site, :after_reset do |site|
     # Suppress warning messages.
     original_verbose, $VERBOSE = $VERBOSE, nil
@@ -62,96 +54,17 @@ module Jekyll
 
     FIXED_DATE_FILENAME_MATCHER = %r!^(?:.+/)*(\d{2,4}-\d{1,2}-\d{1,2})-([^/]*)(\.[^.]+)$!
 
-    # Copy the files from post's folder.
-    #
-    # post - A Post which may have associated content.
-    def copy_post_files(post)
-
-      post_path = Pathname.new post.path
-      site = post.site
-      site_src_dir = Pathname.new site.source
-
-      # Jekyll.logger.warn(
-      #   "[PostFiles]",
-      #   "Current post: #{post_path[site_src_dir.length..-1]}"
-      # )
-
-      post_dir = post_path.dirname
-      dest_dir = Pathname.new(post.destination("")).dirname
-
-      Jekyll.logger.warn("[PostFiles]", "post_path: #{post_path}")
-      Jekyll.logger.warn("[PostFiles]", "post_dir:  #{post_dir}")
-      Jekyll.logger.warn("[PostFiles]", "post_dest: #{post.destination("")}")
-      Jekyll.logger.warn("[PostFiles]", "dest_dir:  #{dest_dir}")
-
-      Jekyll.logger.warn("[PostFiles]", "RETURN")
-      return
-
-      # Count other Markdown files in the same directory
-      other_md_count = 0
-      other_md = Dir.glob(post_dir + '*.{md,markdown}', File::FNM_CASEFOLD) do |mdfilepath|
-        # Jekyll.logger.warn(
-        #   "[PostFiles]",
-        #   "mdfilepath: #{mdfilepath}; post_path.to_path: #{post_path.to_path}"
-        # )
-        # Jekyll.logger.warn("[PostFiles]", "mdfilepath:")
-        # Jekyll.logger.warn("[PostFiles]", "#{mdfilepath}")
-        # Jekyll.logger.warn("[PostFiles]", "post_path.to_path:")
-        # Jekyll.logger.warn("[PostFiles]", "#{post_path.to_path}")
-        if mdfilepath != post_path.to_path
-          other_md_count += 1
-        end
-      end
-
-      contents = Dir.glob(post_dir + '**/*') do |filepath|
-        if filepath != post_path \
-            && !File.directory?(filepath) \
-            && !File.fnmatch?('*.{md,markdown}', filepath, File::FNM_EXTGLOB | File::FNM_CASEFOLD)
-          filepath = Pathname.new(filepath)
-          # Jekyll.logger.warn(
-          #   "[PostFiles]",
-          #   "-> attachment: #{filepath[site_src_dir.length..-1]}"
-          # )
-          if other_md_count > 0
-            Jekyll.logger.abort_with(
-              "[PostFiles]",
-              "Sorry, there can be only one Markdown file in each directory containing other assets to be copied by jekyll-postfiles"
-            )
-          end
-          relpath = filepath.relative_path_from(site_src_dir)
-          filedir, filename = relpath.dirname, relpath.basename
-
-          absfiledir = site_src_dir + filedir
-          new_dir = absfiledir.relative_path_from(post_dir)
-          site.static_files <<
-            PostFile.new(site, site_src_dir, filedir, filename, (dest_dir + new_dir).to_path)
-        end
-      end
-    end
-
     # _posts/
-    #   2018-01-01-whatever.md
-    #   my-cool-post/
-    #     2016-06-09-the-post.md
-    #     cloudflare-architecture.png
-    #     performance-report-sample.pdf
-    # Generate content by copying files associated with each post.
-    #
-    # the working set (site.posts.docs) is proposed by:
-    # jekyll/lib/jekyll/readers/post_reader.rb#read_posts
-    #
-    # only documents matching Document::DATE_FILENAME_MATCHER are accepted.
-    # 
-    # post_reader does not intend to support nesting, but accidentally
-    # includes files under any directory whose name matches DATE_FILENAME_MATCHER
-    #
-    # we'll work around this by restoring the world to a ground truth:
-    # 
+    #   2018-01-01-whatever.md     # there's a date on this filename, so it will be treated as a post
+    #                              # it's a direct descendant of _posts, so we do not treat it as an asset root
+    #   somedir/
+    #     2018-05-01-some-post.md  # there's a date on this filename, so it will be treated as a post.
+    #                              # moreover, we will treat its dir as an asset root
+    #     cool.svg                 # there's no date on this filename, so it will be treated as an asset
+    #     undated.md               # there's no date on this filename, so it will be treated as an asset
+    #     img/
+    #       cool.png               # yes, even deeply-nested files are eligible to be copied.
     def generate(site)
-      # site.posts.docs.each do |post|
-      #   copy_post_files(post)
-      # end
-
       site_src_dir = Pathname.new site.source
       posts_src_dir = site_src_dir + '_posts'
       drafts_src_dir = site_src_dir + '_drafts'
@@ -159,25 +72,16 @@ module Jekyll
       Jekyll.logger.warn("[PostFiles]", "_posts: #{posts_src_dir}")
       Jekyll.logger.warn("[PostFiles]", "docs: #{site.posts.docs.map(&:path)}")
 
-      # # Reject any .md nested deeper than _posts/dir/post.md
-      # site.posts.docs.reject!{ |doc|
-      #   Pathname.new(doc.path).relative_path_from(posts_src_dir).each_filename.count > 2
-      # }
-
-      # markdowns, assets = site.posts.docs.partition{ |doc|
-      #   ['.md', '.markdown'].include?(Pathname.new(doc.path).extname)
-      # }
-
-      # # reject assets; they are not renderable documents
-      # site.posts.docs = markdowns
-
-      # Jekyll.logger.warn("[PostFiles]", "assets: #{assets.map(&:path)}")
-      # Jekyll.logger.warn("[PostFiles]", "docs: #{site.posts.docs.map(&:path)}")
-
       docs_with_dirs = site.posts.docs
-        .reject{ |doc| Pathname.new(doc.path).dirname.eql? posts_src_dir }
+        .reject{ |doc|
+          Pathname.new(doc.path).dirname.instance_eval{ |dirname|
+            [posts_src_dir, drafts_src_dir].reduce(false) {|acc, dir|
+              acc || dirname.eql?(dir)
+            }
+          }
+        }
 
-      Jekyll.logger.warn("[PostFiles]", "docs_with_dirs: #{docs_with_dirs.map{|doc| Pathname.new(doc.path).dirname}}")
+      Jekyll.logger.warn("[PostFiles]", "asset_roots: #{docs_with_dirs.map{|doc| Pathname.new(doc.path).dirname}}")
 
       assets = docs_with_dirs.map{ |doc|
         dest_dir = Pathname.new(doc.destination("")).dirname
@@ -198,33 +102,6 @@ module Jekyll
       }.flatten
 
       site.static_files.concat(assets)
-
-      # any directory deeper than _posts containing multiple .md?
-      # dirs_with_multi_md = site.posts.docs
-      #   .map{ |doc| Pathname.new doc.path }
-      #   .reject{ |path| path.dirname.eql? posts_src_dir }
-      #   .group_by(&:dirname)
-      #   .select{ |key,value| value.count > 1 }
-
-      # if (dirs_with_multi_md.any?)
-      #   Jekyll.logger.abort_with(
-      #     "[PostFiles]",
-      #     "Sorry, there can be only one Markdown file in each directory containing other assets to be copied by jekyll-postfiles. Violations: #{dirs_with_multi_md.map{ |key,value| [key.to_s, value.map(&:to_s)] }.to_h}"
-      #   )
-      # end
-
-      # Jekyll.logger.abort_with(
-      #   "[PostFiles]",
-      #   "don't panic"
-      # )
-
-      # markdowns
-      #   .map{ |doc| Pathname.new(doc.path) }
-      #   .select{ |path|
-      #     path.relative_path_from(posts_src_dir).each_filename.count == 2
-      #   }
-
-      # Pathname.new('/Users/birch/Documents/tmp').relative_path_from(Pathname.new('/Users/birch')).each_filename.count
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/nhoizey/jekyll-postfiles/issues/6, https://github.com/nhoizey/jekyll-postfiles/issues/8.

Input:

```
_posts/
  2018-01-01-whatever.md     # there's a date on this filename, so it will be treated as a post
                             # it's a direct descendant of _posts, so we do not treat it as an asset root
  somedir/
    2018-05-01-some-post.md  # there's a date on this filename, so it will be treated as a post.
                             # moreover, we will treat its dir as an asset root
    cool.svg                 # there's no date on this filename, so it will be treated as an asset
    dateless.md              # there's no date on this filename, so it will be treated as an asset
    img/
      cool.png               # yes, even deeply-nested files are eligible to be copied.
```

Output:

```
dist/blog/[:tag/]*
  :year/:month/:day/
    whatever.md
  :year/:month/:day/
    some-post.md
    cool.svg
    dateless.md
    img/
      cool.png
```

We no longer attach any significance to the file extension .md/.markdown. Instead we do what Jekyll does: classify based on whether there's a date in the filename.  
This is more idiomatic, and makes it possible to write posts in non-markdown formats (i.e. html).

Sub-directories are now supported.

Caveat:

Jekyll's `Document::DATE_FILENAME_MATCHER` encounters some false positives, so I was forced to modify it. May be more appropriate to solve that upstream, but I think ultimately we're the only consumer anyway.